### PR TITLE
server: added unit test for testing pgsql protocol compatibility

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1029,7 +1029,7 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 	case 'S':            /* sync */
 		return cc.writeReadyForQuery(ctx,cc.ctx.Status())
 	case 'X':
-		return nil
+		return io.EOF
 	case 'd':            /* copy data */
 	case 'c':            /* copy done */
 	case 'f':            /* copy fail */

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -644,10 +644,15 @@ func (ts *ConnTestSuite) TestConnExecutionTimeout(c *C) {
 		session: se,
 		stmts:   make(map[int]*TiDBStatement),
 	}
+
+	var outBuffer bytes.Buffer
 	cc := &clientConn{
 		connectionID: uint32(connID),
 		server: &Server{
 			capability: defaultCapability,
+		},
+		pkt: &packetIO{
+			bufWriter: bufio.NewWriter(&outBuffer),
 		},
 		ctx:   tc,
 		alloc: arena.NewAllocator(32 * 1024),


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What's Changed:

server/conn_test.go:
- Added unit test for parse normal Handshake request
- Added unit test for handle malformed handshake
- Added unit test for handle SSL request
- Added unit test for write back authentication OK
- Added unit test for dispatch simple query
- Fixed unit test for connExecutiontimeout which used to panic due to write out of bound
- Commented out old dispatching unit test which uses mysql protocol and is no longer needed

server/conn.go:

-Fixed a small bug within dispatch function, now dispatch will return a EOF error when client disconnect. (used to return nil)

### How it Works:

All unit tests inside server/conn_test should be able to run (no more panic), appropriate test should fail appropriately (dispatchSimpleQueryPG should fail)
